### PR TITLE
fix wrong router that make server stop

### DIFF
--- a/src/api/router.py
+++ b/src/api/router.py
@@ -4,4 +4,4 @@ from src.api.endpoints import embeddings, chat, metrics
 router = APIRouter()
 router.include_router(embeddings.router, prefix="/v1/embeddings", tags=["embeddings"])
 router.include_router(chat.router, prefix="/v1/chat", tags=["chat"])
-router.include_router(metrics, prefix="/v1/metrics", tags=["metrics"])
+router.include_router(metrics.router, prefix="/v1/metrics", tags=["metrics"])


### PR DESCRIPTION
I found that the warning message ```curl: (7) Failed to connect to 0.0.0.0 port 1234 after 0 ms: Connection refused``` always exists after executing ```python scripts/launch.py start --host 0.0.0.0 --port 8888 --reload```.
Dive into server.log and found the issue might exist at https://github.com/rushizirpe/open-llm-server/blob/f155341b3e54e18cdad9f5933acf0f6872c6a466/src/api/router.py#L7
This PR is to add ```.router``` behind ```metrics``` to make the quick fix.